### PR TITLE
Be more defensive about input data.

### DIFF
--- a/test/actions-test.js
+++ b/test/actions-test.js
@@ -1669,9 +1669,30 @@ describe('ApiAiAssistant#ask', function () {
 // ---------------------------------------------------------------------------
 
 /**
- * Describes the behavior for ApiAiAssistant constructor method.
+ * Describes the behavior for ActionsSdkAssistant constructor method.
  */
 describe('ActionsSdkAssistant#constructor', function () {
+  // Success case test, when the API returns a valid 200 response with the response object
+  it('Should produce a useful error with invalid payload.', function () {
+    let headers = {
+      'Content-Type': 'application/json',
+      'Google-Assistant-API-Version': 'v1'
+    };
+    const mockRequest = new MockRequest(headers, {});
+    const mockResponse = new MockResponse();
+
+    const assistant = new ActionsSdkAssistant({
+      request: mockRequest,
+      response: mockResponse
+    });
+
+    let actionMap = new Map();
+    assistant.handleRequest(actionMap);
+
+    // Validating the response object
+    expect(mockResponse.body).to.equal('Action Error: Missing inputs from request body');
+  });
+
   // Calls sessionStarted when provided
   it('Calls sessionStarted when new session', function () {
     let headers = {

--- a/test/actions-test.js
+++ b/test/actions-test.js
@@ -502,7 +502,33 @@ describe('ApiAiAssistant#ask', function () {
 });
 
 /**
- * Describes the behavior for ApiAiAssistant askForPermissions method.
+ * Describes the behavior for ApiAiAssistant ask method.
+ */
+describe('ApiAiAssistant with an invalid payload', function () {
+  // Success case test, when the API returns a valid 200 response with the response object
+  it('Should produce a useful error.', function () {
+    let headers = {
+      'Content-Type': 'application/json',
+      'Google-Assistant-API-Version': 'v1'
+    };
+    const mockRequest = new MockRequest(headers, {});
+    const mockResponse = new MockResponse();
+
+    const assistant = new ApiAiAssistant({
+      request: mockRequest,
+      response: mockResponse
+    });
+
+    let actionMap = new Map();
+    assistant.handleRequest(actionMap);
+
+    // Validating the response object
+    expect(mockResponse.body).to.equal('Action Error: Missing result from request body');
+  });
+});
+
+/**
+ * Describes the behavior for ApiAiAssistant with invalid payload.
  */
 describe('ApiAiAssistant#askForPermissions', function () {
   // Success case test, when the API returns a valid 200 response with the response object


### PR DESCRIPTION
Closes https://github.com/actions-on-google/actions-on-google-nodejs/issues/16.

Both tests fail as such otherwise:

```
  1) ActionsSdkAssistant#constructor Should produce a useful error with invalid payload.:
     TypeError: Cannot read property 'type' of undefined
      at new ActionsSdkAssistant (actions-sdk-assistant.js:64:32)
      at Context.<anonymous> (test/actions-test.js:1684:23)
```