### PR TITLE
Adding defensive check to original request's first argument element

### DIFF
--- a/api-ai-assistant.js
+++ b/api-ai-assistant.js
@@ -276,7 +276,8 @@ const ApiAiAssistant = class extends Assistant {
     }
     if (this.body_.originalRequest && this.body_.originalRequest.data &&
         this.body_.originalRequest.data.inputs &&
-        this.body_.originalRequest.data.inputs[0].arguments) {
+        this.body_.originalRequest.data.inputs[0].arguments &&
+        this.body_.originalRequest.data.inputs[0].arguments[0]) {
       return this.body_.originalRequest.data.inputs[0].arguments[0][argName];
     }
     debug('Failed to get argument value: %s', argName);


### PR DESCRIPTION
I ran into this issue recently while doing some local testing for my action. For some reason, the argument list was empty and I was getting an error.