### PR TITLE
Return a Promise from handleRequest

### DIFF
--- a/assistant-app.js
+++ b/assistant-app.js
@@ -547,8 +547,8 @@ class AssistantApp {
    *     // handle an error
    *   });
    *
-   * // API.AI
-   * const app = new ApiAIApp({request: req, response: res});
+   * // Dialogflow
+   * const app = new DialogflowApp({request: req, response: res});
    * const NAME_ACTION = 'make_name';
    * const COLOR_ARGUMENT = 'color';
    * const NUMBER_ARGUMENT = 'number';

--- a/assistant-app.js
+++ b/assistant-app.js
@@ -508,18 +508,96 @@ class AssistantApp {
    * app.handleRequest(actionMap);
    *
    * @param {(Function|Map)} handler The handler (or Map of handlers) for the request.
-   * @return {Promise} to resolve the result of the handler that was invoked.
+   * @return {undefined}
    * @actionssdk
    * @apiai
    */
   handleRequest (handler) {
     debug('handleRequest: handler=%s', handler);
+    this.handleRequestAsync(handler);
+  }
+
+  /**
+   * Asynchronously handles the incoming Assistant request using a handler or Map of handlers.
+   * Each handler can be a function callback or Promise.
+   *
+   * @example
+   * // Actions SDK
+   * const app = new ActionsSdkApp({request: request, response: response});
+   *
+   * function mainIntent (app) {
+   *   const inputPrompt = app.buildInputPrompt(true, '<speak>Hi! <break time="1"/> ' +
+   *         'I can read out an ordinal like ' +
+   *         '<say-as interpret-as="ordinal">123</say-as>. Say a number.</speak>',
+   *         ['I didn\'t hear a number', 'If you\'re still there, what\'s the number?', 'What is the number?']);
+   *   app.ask(inputPrompt);
+   * }
+   *
+   * function rawInput (app) {
+   *   if (app.getRawInput() === 'bye') {
+   *     app.tell('Goodbye!');
+   *   } else {
+   *     const inputPrompt = app.buildInputPrompt(true, '<speak>You said, <say-as interpret-as="ordinal">' +
+   *       app.getRawInput() + '</say-as></speak>',
+   *         ['I didn\'t hear a number', 'If you\'re still there, what\'s the number?', 'What is the number?']);
+   *     app.ask(inputPrompt);
+   *   }
+   * }
+   *
+   * const actionMap = new Map();
+   * actionMap.set(app.StandardIntents.MAIN, mainIntent);
+   * actionMap.set(app.StandardIntents.TEXT, rawInput);
+   *
+   * app.handleRequest(actionMap)
+   * .then(
+   *   (result) => {
+   *     // handle the result
+   *   })
+   * .catch(
+   *   (reason) => {
+   *     // handle an error
+   *   });
+   *
+   * // API.AI
+   * const app = new ApiAIApp({request: req, response: res});
+   * const NAME_ACTION = 'make_name';
+   * const COLOR_ARGUMENT = 'color';
+   * const NUMBER_ARGUMENT = 'number';
+   *
+   * function makeName (app) {
+   *   const number = app.getArgument(NUMBER_ARGUMENT);
+   *   const color = app.getArgument(COLOR_ARGUMENT);
+   *   app.tell('Alright, your silly name is ' +
+   *     color + ' ' + number +
+   *     '! I hope you like it. See you next time.');
+   * }
+   *
+   * const actionMap = new Map();
+   * actionMap.set(NAME_ACTION, makeName);
+   *
+   * app.handleRequest(actionMap)
+   * .then(
+   *   (result) => {
+   *     // handle the result
+   *   })
+   * .catch(
+   *   (reason) => {
+   *     // handle an error
+   *   });
+   *
+   * @param {(Function|Map)} handler The handler (or Map of handlers) for the request.
+   * @return {Promise} to resolve the result of the handler that was invoked.
+   * @actionssdk
+   * @apiai
+   */
+  handleRequestAsync (handler) {
+    debug('handleRequestAsync: handler=%s', handler);
     if (!handler) {
       this.handleError_('request handler can NOT be empty.');
       return Promise.reject(new Error('request handler can NOT be empty.'));
     }
     if (typeof handler === 'function') {
-      debug('handleRequest: function');
+      debug('handleRequestAsync: function');
       // simple function handler
       this.handler_ = handler;
       const handlerResult = handler(this);

--- a/assistant-app.js
+++ b/assistant-app.js
@@ -515,7 +515,7 @@ class AssistantApp {
     debug('handleRequest: handler=%s', handler);
     if (!handler) {
       this.handleError_('request handler can NOT be empty.');
-      return;
+      return false;
     }
     if (typeof handler === 'function') {
       debug('handleRequest: function');
@@ -523,7 +523,7 @@ class AssistantApp {
       this.handler_ = handler;
       const promise = handler(this);
       if (promise instanceof Promise) {
-        promise.then(
+        return promise.then(
           (result) => {
             debug(result);
           })
@@ -534,9 +534,9 @@ class AssistantApp {
           });
       } else {
         // Handle functions
-        return;
+        return true;
       }
-      return;
+      return false;
     } else if (handler instanceof Map) {
       debug('handleRequest: map');
       const intent = this.getIntent();
@@ -544,7 +544,7 @@ class AssistantApp {
       if (!result) {
         this.tell(!this.lastErrorMessage_ ? ERROR_MESSAGE : this.lastErrorMessage_);
       }
-      return;
+      return result;
     }
     // Could not handle intent
     this.handleError_('invalid intent handler type: ' + (typeof handler));
@@ -1707,7 +1707,7 @@ class AssistantApp {
         debug('map of intents');
         const promise = value(this);
         if (promise instanceof Promise) {
-          promise.then(
+          return promise.then(
             (result) => {
               // No-op
             })

--- a/assistant-app.js
+++ b/assistant-app.js
@@ -526,11 +526,13 @@ class AssistantApp {
         return promise.then(
           (result) => {
             debug(result);
+            return result;
           })
         .catch(
           (reason) => {
             this.handleError_('function failed: %s', reason.message);
             this.tell(!reason.message ? ERROR_MESSAGE : reason.message);
+            return reason;
           });
       } else {
         // Handle functions
@@ -1710,13 +1712,14 @@ class AssistantApp {
           return promise.then(
             (result) => {
               // No-op
+              return result;
             })
           .catch(
             (reason) => {
               error(reason.message);
               this.handleError_('intent handler failed: %s', reason.message);
               this.lastErrorMessage_ = reason.message;
-              return false;
+              return reason;
             });
         } else {
           // Handle functions

--- a/assistant-app.js
+++ b/assistant-app.js
@@ -577,7 +577,7 @@ class AssistantApp {
    * @param {(Function|Map)} handler The handler (or Map of handlers) for the request.
    * @return {Promise} to resolve the result of the handler that was invoked.
    * @actionssdk
-   * @apiai
+   * @dialogflow
    */
   handleRequestAsync (handler) {
     debug('handleRequestAsync: handler=%s', handler);

--- a/test/assistant-app-test.js
+++ b/test/assistant-app-test.js
@@ -162,7 +162,7 @@ describe('AssistantApp', function () {
     });
   });
 
-  describe('#handleRequest', function () {
+  describe('#handleRequestAsync', function () {
     let mockRequest;
     let app;
 
@@ -184,7 +184,7 @@ describe('AssistantApp', function () {
       const actionMap = new Map();
       actionMap.set(mockRequest.body.result.action, handler);
 
-      app.handleRequest(actionMap).then(
+      app.handleRequestAsync(actionMap).then(
         (result) => {
           expect(result).to.equal('success');
           done();
@@ -200,7 +200,7 @@ describe('AssistantApp', function () {
       const actionMap = new Map();
       actionMap.set(mockRequest.body.result.action, handler);
 
-      app.handleRequest(actionMap).catch(
+      app.handleRequestAsync(actionMap).catch(
         (reason) => {
           expect(reason).to.be.a('Error');
           done();
@@ -213,7 +213,7 @@ describe('AssistantApp', function () {
         return Promise.resolve('success');
       };
 
-      app.handleRequest(handler).then(
+      app.handleRequestAsync(handler).then(
         (result) => {
           expect(result).to.equal('success');
           done();
@@ -226,7 +226,7 @@ describe('AssistantApp', function () {
         return Promise.reject(new Error('error'));
       };
 
-      app.handleRequest(handler).catch(
+      app.handleRequestAsync(handler).catch(
         (reason) => {
           expect(reason).to.be.a('Error');
           done();
@@ -239,7 +239,7 @@ describe('AssistantApp', function () {
         return 'success';
       };
 
-      app.handleRequest(handler).then(
+      app.handleRequestAsync(handler).then(
         (result) => {
           expect(result).to.equal('success');
           done();
@@ -255,7 +255,7 @@ describe('AssistantApp', function () {
       const actionMap = new Map();
       actionMap.set(mockRequest.body.result.action, handler);
 
-      app.handleRequest(actionMap).then(
+      app.handleRequestAsync(actionMap).then(
         (result) => {
           expect(result).to.equal('success');
           done();

--- a/test/assistant-app-test.js
+++ b/test/assistant-app-test.js
@@ -28,7 +28,7 @@ const expect = chai.expect;
 const spies = require('chai-spies');
 const { AssistantApp } = require('.././actions-on-google');
 const {
-  apiAiAppRequestBodyNewSessionMock,
+  dialogflowAppRequestBodyNewSessionMock,
   headerV1,
   headerV2,
   MockRequest,
@@ -167,7 +167,7 @@ describe('AssistantApp', function () {
     let app;
 
     beforeEach(function () {
-      mockRequest = new MockRequest(headerV2, JSON.parse(JSON.stringify(apiAiAppRequestBodyNewSessionMock)));
+      mockRequest = new MockRequest(headerV2, JSON.parse(JSON.stringify(dialogflowAppRequestBodyNewSessionMock)));
       app = new AssistantApp({request: mockRequest, response: mockResponse});
 
       // mock getIntent

--- a/test/assistant-app-test.js
+++ b/test/assistant-app-test.js
@@ -228,5 +228,34 @@ describe('AssistantApp', function () {
         }
       );
     });
+
+    it('Should resolve a promise when handler function does not return a promise', function (done) {
+      let handler = app => {
+        return 'success';
+      };
+
+      app.handleRequest(handler).then(
+        (result) => {
+          expect(result).to.equal('success');
+          done();
+        }
+      );
+    });
+
+    it('Should resolve a promise when actionMap contains a handler that does not return a promise', function (done) {
+      let handler = app => {
+        return 'success';
+      };
+
+      const actionMap = new Map();
+      actionMap.set(mockRequest.body.result.action, handler);
+
+      app.handleRequest(actionMap).then(
+        (result) => {
+          expect(result).to.equal('success');
+          done();
+        }
+      );
+    });
   });
 });

--- a/test/assistant-app-test.js
+++ b/test/assistant-app-test.js
@@ -26,7 +26,7 @@ const winston = require('winston');
 const chai = require('chai');
 const expect = chai.expect;
 const spies = require('chai-spies');
-const { AssistantApp, ApiAiApp } = require('.././actions-on-google');
+const { AssistantApp } = require('.././actions-on-google');
 const {
   apiAiAppRequestBodyNewSessionMock,
   headerV1,
@@ -168,7 +168,12 @@ describe('AssistantApp', function () {
 
     beforeEach(function () {
       mockRequest = new MockRequest(headerV2, JSON.parse(JSON.stringify(apiAiAppRequestBodyNewSessionMock)));
-      app = new ApiAiApp({request: mockRequest, response: mockResponse});
+      app = new AssistantApp({request: mockRequest, response: mockResponse});
+
+      // mock getIntent
+      app.getIntent = () => {
+        return mockRequest.body.result.action;
+      };
     });
 
     it('Should resolve a promise when actionMap contains a handler that returns a promise', function (done) {


### PR DESCRIPTION
Currently when handleRequest is called, and the map of request handlers contains functions that return promises, the promise is swallowed by handleRequest and we are unable to handle the then or catch events.

An example of when this would be useful is when we have a callback function to call in our nodejs environment that we would like to call after handleRequest has internally resolved the promises.

Our solution is to return the promise from within handleRequest and invokeIntentHandler_, or true/false for non promise handlers.

Returning true/false when the request handler does not return a promise may not be the best idea.

I suggest we always return a promise when calling handleRequest. And return Promise.resolve or Promise.reject instead of true/false.