### PR TITLE
remove hardcoded env var for debug

### DIFF
--- a/utils/transform.js
+++ b/utils/transform.js
@@ -16,9 +16,6 @@
 
 'use strict';
 
-// Enable actions-on-google debug logging
-process.env.DEBUG = 'actions-on-google:*';
-
 // lodash helpers
 const camelCase = require('lodash.camelcase');
 const snakeCase = require('lodash.snakecase');


### PR DESCRIPTION
This line causes issues for debug users (like express and many many others) and goes against the purpose of env variables and 12 factor apps.