### PR TITLE
Debug instead of error log on missing user

### DIFF
--- a/assistant-app.js
+++ b/assistant-app.js
@@ -1372,7 +1372,7 @@ class AssistantApp {
     const data = this.requestData();
 
     if (!data || !data.user) {
-      error('No user object');
+      debug('No user object');
       return null;
     }
 


### PR DESCRIPTION
A Dialogflow test request won't include a user object but this code will still get called during a `handleRequest`, so this shouldn't be an error.