### PR TITLE
Conversation id from originalRequest accessible from DialogFlowApp

### DIFF
--- a/dialogflow-app.js
+++ b/dialogflow-app.js
@@ -1069,6 +1069,27 @@ class DialogflowApp extends AssistantApp {
   }
 
   /**
+   * Gets the unique conversation ID. It's a new ID for the initial query,
+   * and stays the same until the end of the conversation.
+   *
+   * @example
+   * const app = new DialogflowApp({request: request, response: response});
+   * const conversationId = app.getConversationId();
+   *
+   * @return {string} Conversation ID or null if no value.
+   * @dialogflow
+   */
+  getConversationId () {
+    debug('getConversationId');
+    if (!this.body_.originalRequest.data.conversation ||
+        !this.body_.originalRequest.data.conversation.conversationId) {
+      error('No conversation ID');
+      return null;
+    }
+    return this.body_.originalRequest.data.conversation.conversationId;
+  }
+
+  /**
    * Uses a given intent spec to construct and send a non-TEXT intent response
    * to Google.
    *

--- a/test/dialogflow-app-test.js
+++ b/test/dialogflow-app-test.js
@@ -41,6 +41,7 @@ const {
   headerV2,
   MockResponse,
   MockRequest,
+  fakeConversationId,
   clone
 } = require('./utils/mocking');
 
@@ -2181,6 +2182,23 @@ describe('DialogflowApp', function () {
       });
 
       expect(app.getIntent()).to.equal('check_guess');
+    });
+  });
+
+  /**
+   * Describes the behavior for DialogflowApp getConversationId method.
+   */
+  describe('#getConversationId', function () {
+    // Success case test, when the API returns a valid 200 response with the response object
+    it('Should validate assistant conversation ID.', function () {
+      dialogflowAppRequestBodyLiveSession
+          .originalRequest.data.conversation.conversationId = fakeConversationId;
+      const mockRequest = new MockRequest(headerV1, dialogflowAppRequestBodyLiveSession);
+      const app = new DialogflowApp({
+        request: mockRequest,
+        response: mockResponse
+      });
+      expect(app.getConversationId()).to.equal(fakeConversationId);
     });
   });
 


### PR DESCRIPTION
Currently there is no way to get conversationId from DialogFlowApp object. This value can be useful e.g. with session identification in external analytics tools. 
Instead of accessing it from request object, this PR makes it accessible from DialogFlowApp.