### PR TITLE
Support Events. closes #64

### DIFF
--- a/dialogflow-app.js
+++ b/dialogflow-app.js
@@ -962,10 +962,10 @@ class DialogflowApp extends AssistantApp {
       if (textToSpeech.speech) {
         // Convert SimpleResponse to RichResponse
         textToSpeech = this.buildRichResponse().addSimpleResponse(textToSpeech);
-      } else if (!(textToSpeech.items &&
+      } else if (!((textToSpeech.items &&
         textToSpeech.items[0] &&
-        textToSpeech.items[0].simpleResponse)) {
-        error('Invalid RichResponse. First item must be SimpleResponse');
+        textToSpeech.items[0].simpleResponse) || textToSpeech.event)) {
+        error('Invalid RichResponse. First item must be simpleResponse or contains an event');
         return null;
       }
     }
@@ -987,11 +987,17 @@ class DialogflowApp extends AssistantApp {
       noInputs = [];
     }
     const response = {
-      speech: isStringResponse ? textToSpeech
-        : textToSpeech.items[0].simpleResponse.textToSpeech ||
-        textToSpeech.items[0].simpleResponse.ssml,
       contextOut: []
     };
+    const simpleResponse = isStringResponse ? null
+      : textToSpeech.items[0] && textToSpeech.items[0].simpleResponse;
+    if (isStringResponse || simpleResponse) {
+      response.speech = isStringResponse ? textToSpeech
+      : simpleResponse.textToSpeech || simpleResponse.ssml;
+    }
+    if (textToSpeech.event) {
+      response.followupEvent = textToSpeech.event;
+    }
     const google = Object.assign({
       expectUserResponse,
       noInputPrompts: noInputs

--- a/response-builder.js
+++ b/response-builder.js
@@ -114,6 +114,13 @@ const ImageDisplays = {
  *     to indicate this option if they do not use the key.
  */
 
+ /**
+ * Event. Used in rich response as followupEvent to trigger another intent.
+ * @typedef {Object} Event
+ * @property {string} name - event name
+ * @property {Object} data - a map with parameter name as key and their parameter value as value
+ */
+
 /**
  * @typedef {Object} StructuredResponse
  * @property {OrderUpdate} orderUpdate
@@ -165,6 +172,12 @@ class RichResponse {
      */
     this.linkOutSuggestion = undefined;
 
+    /**
+     * Add event for this rich response. Optional.
+     * @type {Event}
+     */
+    this.event = undefined;
+
     if (richResponse) {
       if (richResponse.items) {
         this.items = richResponse.items;
@@ -213,7 +226,7 @@ class RichResponse {
     if (this.items.length > 0 && (this.items[0].basicCard ||
       this.items[0].structuredResponse)) {
       this.items.unshift(simpleResponseObj);
-    } else {
+    } else if (simpleResponseObj.simpleResponse){
       this.items.push(simpleResponseObj);
     }
     return this;
@@ -240,6 +253,26 @@ class RichResponse {
     this.items.push({
       basicCard: basicCard
     });
+    return this;
+  }
+
+  /**
+   * Set an Event to this rich response
+   *
+   * @param {string} name - event name
+   * @param {Object} payload - event data, a map with parameter name as key and their
+   * parameter value as value
+   * @return {RichResponse} Returns current constructed RichResponse.
+   */
+  setEvent (name, payload) {
+    if (!(typeof name === 'string' || (payload && typeof payload === 'object'))) {
+      error('Invalid event');
+      return this;
+    }
+    this.event = { name };
+    if (payload) {
+      this.event.data = payload;
+    }
     return this;
   }
 


### PR DESCRIPTION
Despite there being two pull request based on that I personally consider that:

- Events, or followUpEvents is may be related with contexts but on the contrary they are a response themselves.
- It might has no preference for tell or ask.

So I think events has to be in the response builder workflow. Then you can send them with ask or tell.

usage:
const googleResponse = <app>.buildRichResponse(); // build your rich response as usual.
googleResponse.setEvent('event-name', {param1: value1, param2: value2, ...});
<app>.ask(googleResponse); or <app>.tell(googleResponse);

Speech and followupEvent will both be sent, although they are incompatible see https://dialogflow.com/docs/events#invoking_event_from_webhook but I personally believe it is responsible of the other side and this pull request won't block any future development.