### PR TITLE
fixes unspecified payment type

### DIFF
--- a/transactions.js
+++ b/transactions.js
@@ -293,7 +293,7 @@ const TransactionValues = {
     /**
      * Unspecified.
      */
-    UNSPECIFIED: 'UNSPECIFIED',
+    PAYMENT_TYPE_UNSPECIFIED: 'PAYMENT_TYPE_UNSPECIFIED',
     /**
      * Payment card.
      */


### PR DESCRIPTION
According to the [documentation](https://developers.google.com/actions/reference/rest/Shared.Types/PaymentType) and my testing **UNSPECIFIED** isn't correct. **PAYMENT_TYPE_UNSPECIFIED** addresses the issue.