### PR TITLE
[Docs] Add Link to GH Page on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Actions on Google Client Library
 
 This client library makes it easy to create your apps for the Google Assistant, and
-supports both Dialogflow fulfillment and the Actions SDK webhook.
+supports both Dialogflow fulfillment and the Actions SDK webhook. [Documentation](https://actions-on-google.github.io/actions-on-google-nodejs/).
 
 [![NPM Version](https://img.shields.io/npm/v/actions-on-google.svg)](https://www.npmjs.org/package/actions-on-google)
 [![Build Status](https://travis-ci.org/actions-on-google/actions-on-google-nodejs.svg?branch=master)](https://travis-ci.org/actions-on-google/actions-on-google-nodejs)


### PR DESCRIPTION
## Background
Despite the recently added v2 documentation reference with great new styles, there did not seem to be a link to the generated output. This PR seeks to save additional googling to hunt down the documentation.

## Changes
- Updates README.md

## Addresses
#115 