### PR TITLE
Add content-type header to lambda response

### DIFF
--- a/src/framework/lambda.ts
+++ b/src/framework/lambda.ts
@@ -40,6 +40,9 @@ export class Lambda implements Framework<LambdaHandler> {
       const { status, body } = result
       callback(null, {
         statusCode: status,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8'
+        },
         body: JSON.stringify(body),
       })
     }


### PR DESCRIPTION
Hey,

Had to set the `Content-Type` header to `application/json; charset=utf-8` in the response in order to get the Swedish characters `åäö` working.

Perhaps a sane header to have set in the response?

