### PR TITLE
Support Static Reprompts.

### DIFF
--- a/src/service/actionssdk/_test/conversation.test.ts
+++ b/src/service/actionssdk/_test/conversation.test.ts
@@ -21,7 +21,7 @@ import {
   ActionsSdkConversationOptions,
   ActionsSdkConversation,
 } from '../conv'
-import { BasicCard, Button, Suggestions } from '..'
+import { BasicCard, Button, Suggestions, SimpleResponse } from '..'
 
 const CONVERSATION_ID = '1234'
 const USER_ID = 'abcd'
@@ -234,6 +234,27 @@ test('basic card with suggestions conversation response', t => {
   t.deepEqual(response.richResponse.items![1].basicCard!.formattedText,
     'This is a sample text')
   t.deepEqual(response.richResponse.suggestions![0].title, 'suggestion one')
+  t.true(response.expectUserResponse)
+  t.true(conv.digested)
+  t.true(conv._responded)
+})
+
+test('basic conversation response with reprompts', t => {
+  const appRequest = buildRequest('ACTIVE', 'example.foo')
+  const options = {
+    body: appRequest,
+  } as ActionsSdkConversationOptions<{}, {}>
+  const conv = new ActionsSdkConversation(options)
+
+  conv.ask('hello')
+  conv.noInputs = ['reprompt1', new SimpleResponse('reprompt2')]
+  const response = conv.response()
+
+  t.is(response.richResponse.items!.length, 1)
+  t.deepEqual(response.richResponse.items![0].simpleResponse!.textToSpeech,
+    'hello')
+  t.deepEqual(response.noInputPrompts![0].textToSpeech, 'reprompt1')
+  t.deepEqual(response.noInputPrompts![1].textToSpeech, 'reprompt2')
   t.true(response.expectUserResponse)
   t.true(conv.digested)
   t.true(conv._responded)

--- a/src/service/actionssdk/conv.ts
+++ b/src/service/actionssdk/conv.ts
@@ -98,9 +98,11 @@ export class ActionsSdkConversation<
       expectUserResponse,
       userStorage,
       expectedIntent,
+      noInputPrompts,
     } = this.response()
     const inputPrompt: Api.GoogleActionsV2InputPrompt = {
       richInitialPrompt: richResponse,
+      noInputPrompts,
     }
     const possibleIntents: Api.GoogleActionsV2ExpectedIntent[] = [expectedIntent || {
       intent: 'actions.intent.TEXT',

--- a/src/service/actionssdk/conversation/conversation.ts
+++ b/src/service/actionssdk/conversation/conversation.ts
@@ -203,7 +203,23 @@ export class Conversation<TUserStorage> {
   screen: boolean
 
   /**
-   * Reprompts when no input.
+   * Set reprompts when users don't provide input to this action (no-input errors).
+   * Each reprompt represents as the {@link SimpleResponse}, but raw strings also can be specified
+   * for convenience (they're passed to the constructor of {@link SimpleResponse}).
+   *
+   * @example
+   * ```javascript
+   *
+   * app.intent('actions.intent.MAIN', conv => {
+   *   conv.noInputs = [
+   *     'Are you still there?',
+   *     new SimpleResponse('Hello?'),
+   *     'Talk to you later. Bye!'
+   *   ]
+   *   conv.ask('What's your favorite color?')
+   * })
+   * ```
+   *
    * @public
    */
   noInputs: (string | SimpleResponse)[] = []

--- a/src/service/actionssdk/conversation/conversation.ts
+++ b/src/service/actionssdk/conversation/conversation.ts
@@ -26,6 +26,7 @@ import {
   RichResponseItem,
   MediaObject,
   MediaResponse,
+  SimpleResponse,
 } from './response'
 import { Question, SoloQuestion } from './question'
 import { Arguments } from './argument'
@@ -91,6 +92,7 @@ export interface ConversationResponse {
   expectUserResponse: boolean
   userStorage: string
   expectedIntent?: Api.GoogleActionsV2ExpectedIntent
+  noInputPrompts?: Api.GoogleActionsV2SimpleResponse[]
 }
 
 export interface ConversationOptionsInit<TConvData, TUserStorage> {
@@ -199,6 +201,12 @@ export class Conversation<TUserStorage> {
    * @public
    */
   screen: boolean
+
+  /**
+   * Reprompts when no input.
+   * @public
+   */
+  noInputs: (string | SimpleResponse)[] = []
 
   /** @hidden */
   _raw?: JsonObject
@@ -398,11 +406,18 @@ export class Conversation<TUserStorage> {
       richResponse.add(response)
     }
     const userStorage = this.user._serialize()
+    let noInputPrompts: Api.GoogleActionsV2SimpleResponse[] | undefined
+    if (this.noInputs.length > 0) {
+      noInputPrompts = this.noInputs.map(prompt => {
+        return (typeof prompt === 'string') ? new SimpleResponse(prompt) : prompt
+      })
+    }
     return {
       expectUserResponse,
       richResponse,
       userStorage,
       expectedIntent,
+      noInputPrompts,
     }
   }
 }

--- a/src/service/actionssdk/conversation/conversation.ts
+++ b/src/service/actionssdk/conversation/conversation.ts
@@ -206,6 +206,8 @@ export class Conversation<TUserStorage> {
    * Set reprompts when users don't provide input to this action (no-input errors).
    * Each reprompt represents as the {@link SimpleResponse}, but raw strings also can be specified
    * for convenience (they're passed to the constructor of {@link SimpleResponse}).
+   * Notice that this value is not kept over conversations. Thus, it is necessary to set
+   * the reprompts per each conversation response.
    *
    * @example
    * ```javascript
@@ -213,8 +215,11 @@ export class Conversation<TUserStorage> {
    * app.intent('actions.intent.MAIN', conv => {
    *   conv.noInputs = [
    *     'Are you still there?',
-   *     new SimpleResponse('Hello?'),
-   *     'Talk to you later. Bye!'
+   *     'Hello?',
+   *     new SimpleResponse({
+   *       text: 'Talk to you later. Bye!',
+   *       speech: '<speak>Talk to you later. Bye!</speak>'
+   *     })
    *   ]
    *   conv.ask('What's your favorite color?')
    * })

--- a/src/service/dialogflow/_test/conv.test.ts
+++ b/src/service/dialogflow/_test/conv.test.ts
@@ -21,7 +21,7 @@ import * as ActionsApi from '../../actionssdk/api/v2'
 import { ContextValues } from '../context'
 import { Incoming } from '../incoming'
 import { clone } from '../../../common'
-import { Permission } from '../../actionssdk'
+import { Permission, SimpleResponse } from '../../actionssdk'
 
 interface AvaContext {
   conv: DialogflowConversation
@@ -395,6 +395,58 @@ test('conv.serialize returns the correct response with permission response', t =
     outputContexts: [
       {
         name: 'abcdefg1234567/contexts/_actions_on_google',
+        lifespanCount: 99,
+        parameters: {
+          data: '{}',
+        },
+      },
+    ],
+  })
+})
+
+test('conv.serialize returns the correct response with simple response string and reprompts', t => {
+  const response = 'abc123'
+  const reprompt1 = 'repromt123'
+  const reprompt2 = 'repromt456'
+  const session = 'abcdefg1234567'
+  const conv = new DialogflowConversation({
+    body: {
+      session,
+      originalDetectIntentRequest: {
+        payload: {},
+      },
+    } as Api.GoogleCloudDialogflowV2WebhookRequest,
+    headers: {},
+  })
+  conv.add(response)
+  conv.noInputs = [reprompt1, new SimpleResponse(reprompt2)]
+  t.deepEqual(clone(conv.serialize()), {
+    payload: {
+      google: {
+        expectUserResponse: true,
+        richResponse: {
+          items: [
+            {
+              simpleResponse: {
+                textToSpeech: 'abc123',
+              },
+            },
+          ],
+        },
+        noInputPrompts: [
+          {
+            textToSpeech: reprompt1,
+          },
+          {
+            textToSpeech: reprompt2,
+          },
+        ],
+        userStorage: '{"data":{}}',
+      },
+    },
+    outputContexts: [
+      {
+        name: `${session}/contexts/_actions_on_google`,
         lifespanCount: 99,
         parameters: {
           data: '{}',

--- a/src/service/dialogflow/conv.ts
+++ b/src/service/dialogflow/conv.ts
@@ -311,6 +311,7 @@ export class DialogflowConversation<
       expectUserResponse,
       userStorage,
       expectedIntent,
+      noInputPrompts,
     } = this.response()
     const google: GoogleAssistantResponse = {
       expectUserResponse,
@@ -320,6 +321,7 @@ export class DialogflowConversation<
         intent: expectedIntent.intent!,
         data: expectedIntent.inputValueData as ProtoAny<string, JsonObject>,
       },
+      noInputPrompts,
     }
     const payload: PayloadGoogle = {
       google,


### PR DESCRIPTION
This pull request is to solve the issue #185.

# Purpose of this pull request

Until this sdk version 1, we could use the static reprompts feature. For example, we could specify the phrases to the 2nd argument of the `app.ask` and the `app.tell` functions as like the following code:

```js
app.ask("What is your favorite color?", [
  "Are you still there?", "Hello?", "Sorry, talk to you later. Bye!"
]);
```

Unfortunately, in the latest version of this sdk, we cannot use the static prompts feature. That is, there is no any interfaces to pass the phrases. I would like to add such interface to support the static reprompts feature in this sdk version 2. For example, I propose an idea to specify them using the following code:

```js
app.intent("Default Welcome Intent", conv => {
  conv.noInputs = ["Are you still there?", "Hello?", "Sorry, talk to you later. Bye!"];
  conv.ask("What is your favorite color?");
});
```
# Change points of this pull request

* Add a new property `noInputs`: [here](https://github.com/actions-on-google/actions-on-google-nodejs/pull/186/files#diff-d7e37d9c449c8736c48d78f17cfab23fR209)
  * The property can have both `SimpleResponse` objects and string values for convenience.
* Currently, the `response` function of the `Conversation` class doesn't provide any `noInputPrompts` objects. In this pull request, if the `noInputs` has one or more values, the function creates the array of the `SimpleResponse` object and sets the array to the `noInputPrompts` to include them into the response: [here](https://github.com/actions-on-google/actions-on-google-nodejs/pull/186/files#diff-d7e37d9c449c8736c48d78f17cfab23fR409)
* The passed prompts are set to the `noInputPrompts` property of the `Api.GoogleActionsV2InputPrompt` for Actions SDK: [here](https://github.com/actions-on-google/actions-on-google-nodejs/pull/186/files#diff-00919eb14ef64580120ac246322757f1R105)
* The passed prompts are set to the `noInputPrompts` property of the `GoogleAssistantResponse` for Dialogflow: [here](https://github.com/actions-on-google/actions-on-google-nodejs/pull/186/files#diff-59168c08b7c8c7dbdb43f6bdc1ca0b81R324)