### PR TITLE
conv.followup now retains existing information (i.e. conv.data)

### DIFF
--- a/src/service/dialogflow/_test/conv.test.ts
+++ b/src/service/dialogflow/_test/conv.test.ts
@@ -182,11 +182,9 @@ test('conv.followup sets the raw json correctly with no parameters', t => {
     headers: {},
   })
   conv.followup(event)
-  t.deepEqual(clone(conv._raw), {
-    followupEventInput: {
-      name: event,
-      languageCode: lang,
-    },
+  t.deepEqual(clone(conv._raw!.followupEventInput), {
+    name: event,
+    languageCode: lang,
   })
 })
 
@@ -209,12 +207,10 @@ test('conv.followup sets the raw json correctly with parameters', t => {
     headers: {},
   })
   conv.followup(event, parameters)
-  t.deepEqual(conv._raw, {
-    followupEventInput: {
-      name: event,
-      languageCode: lang,
-      parameters,
-    },
+  t.deepEqual(conv._raw!.followupEventInput, {
+    name: event,
+    languageCode: lang,
+    parameters,
   })
 })
 
@@ -237,12 +233,10 @@ test('conv.followup sets the raw json correctly with parameters and lang', t => 
     headers: {},
   })
   conv.followup(event, parameters, lang)
-  t.deepEqual(conv._raw, {
-    followupEventInput: {
-      name: event,
-      languageCode: lang,
-      parameters,
-    },
+  t.deepEqual(conv._raw!.followupEventInput, {
+    name: event,
+    languageCode: lang,
+    parameters,
   })
 })
 

--- a/src/service/dialogflow/_test/conv.test.ts
+++ b/src/service/dialogflow/_test/conv.test.ts
@@ -182,7 +182,9 @@ test('conv.followup sets the raw json correctly with no parameters', t => {
     headers: {},
   })
   conv.followup(event)
-  t.deepEqual(clone(conv._raw!.followupEventInput), {
+  const followup = (conv.serialize() as Api.GoogleCloudDialogflowV2WebhookResponse)
+    .followupEventInput
+  t.deepEqual(clone(followup), {
     name: event,
     languageCode: lang,
   })
@@ -207,7 +209,7 @@ test('conv.followup sets the raw json correctly with parameters', t => {
     headers: {},
   })
   conv.followup(event, parameters)
-  t.deepEqual(conv._raw!.followupEventInput, {
+  t.deepEqual((conv.serialize() as Api.GoogleCloudDialogflowV2WebhookResponse).followupEventInput, {
     name: event,
     languageCode: lang,
     parameters,
@@ -233,7 +235,7 @@ test('conv.followup sets the raw json correctly with parameters and lang', t => 
     headers: {},
   })
   conv.followup(event, parameters, lang)
-  t.deepEqual(conv._raw!.followupEventInput, {
+  t.deepEqual((conv.serialize() as Api.GoogleCloudDialogflowV2WebhookResponse).followupEventInput, {
     name: event,
     languageCode: lang,
     parameters,

--- a/src/service/dialogflow/conv.ts
+++ b/src/service/dialogflow/conv.ts
@@ -263,7 +263,7 @@ export class DialogflowConversation<
    * Triggers an intent of your choosing by sending a followup event from the webhook.
    * Final response can theoretically include responses but these will not be handled
    * by Dialogflow. Dialogflow will not pass anything back to Google Assistant, therefore
-   * Google Assistant specific information, most notably conv.user.data, is ignored.
+   * Google Assistant specific information, most notably conv.user.storage, is ignored.
    *
    * @example
    * ```javascript

--- a/src/service/dialogflow/conv.ts
+++ b/src/service/dialogflow/conv.ts
@@ -184,7 +184,7 @@ export class DialogflowConversation<
   version: number
 
   /** @hidden */
-  _followup?: JsonObject
+  _followup?: Api.GoogleCloudDialogflowV2EventInput | ApiV1.DialogflowV1FollowupEvent
 
   /** @public */
   constructor(options: DialogflowConversationOptions<TConvData, TUserStorage>) {
@@ -261,10 +261,9 @@ export class DialogflowConversation<
 
   /**
    * Triggers an intent of your choosing by sending a followup event from the webhook.
-   * Final response can theoretically include responses and Action SDK specific data but
-   * these will not be handled by Dialogflow nor Google Assistant respectively.
-   * Contexts will be persisted and new contexts can be inserted (conv.data is also
-   * persisted through contexts).
+   * Final response can theoretically include responses but these will not be handled
+   * by Dialogflow. Dialogflow will not pass anything back to Google Assistant, therefore
+   * Google Assistant specific information, most notably conv.user.data, is ignored.
    *
    * @example
    * ```javascript

--- a/src/service/dialogflow/conv.ts
+++ b/src/service/dialogflow/conv.ts
@@ -285,22 +285,23 @@ export class DialogflowConversation<
    * @public
    */
   followup(event: string, parameters?: Parameters, lang?: string) {
+    this._responded = true
     if (this.version === 1) {
-      return this.json<ApiV1.DialogflowV1WebhookResponse>({
-        followupEvent: {
-          name: event,
-          data: parameters,
-        },
-      })
-    }
-    const body = this.body as Api.GoogleCloudDialogflowV2WebhookRequest
-    return this.json<Api.GoogleCloudDialogflowV2WebhookResponse>({
-      followupEventInput: {
+      const serialization = this.serialize() as ApiV1.DialogflowV1WebhookResponse
+      serialization.followupEvent = {
         name: event,
-        parameters,
-        languageCode: lang || body.queryResult!.languageCode,
-      },
-    })
+        data: parameters,
+      }
+      return this.json<ApiV1.DialogflowV1WebhookResponse>(serialization)
+    }
+    const serialization = this.serialize() as Api.GoogleCloudDialogflowV2WebhookResponse
+    const body = this.body as Api.GoogleCloudDialogflowV2WebhookRequest
+    serialization.followupEventInput = {
+      name: event,
+      parameters,
+      languageCode: lang || body.queryResult!.languageCode,
+    }
+    return this.json<Api.GoogleCloudDialogflowV2WebhookResponse>(serialization)
   }
 
   /** @public */


### PR DESCRIPTION
Proposed change: https://github.com/actions-on-google/actions-on-google-nodejs/issues/210