### PR TITLE
Sync: Optional agentUserId

### DIFF
--- a/src/service/smarthome/api/v1.ts
+++ b/src/service/smarthome/api/v1.ts
@@ -116,7 +116,7 @@ export interface SmartHomeV1SyncDevices {
 }
 
 export interface SmartHomeV1SyncPayload {
-  agentUserId: string,
+  agentUserId?: string,
   errorCode?: string,
   debugString?: string,
   devices: SmartHomeV1SyncDevices[]


### PR DESCRIPTION
In case of an invalid authentication token, the `agentUserId` won't be available.

In such cases I expect a valid response to only include:

```
{
  requestId: body.requestId,
  payload: {
    errorCode: 'authFailure',
    devices: []
  },
}
```

but this currently throws an error when running typescript in strict mode as `agentUserId` is not optional.

The property is also documented as optional here https://developers.google.com/actions/smarthome/create#actiondevicessync