### PR TITLE
Fix unhandled exception in jwtClient.authorize

### DIFF
--- a/src/service/smarthome/smarthome.ts
+++ b/src/service/smarthome/smarthome.ts
@@ -330,7 +330,7 @@ const makeApiCall = (url: string, data: JsonObject, jwt?: SmartHomeJwt): Promise
       )
       jwtClient.authorize((err: Error, tokens: JsonObject) => {
         if (err) {
-          reject(err)
+          return reject(err)
         }
         options.headers = {
           Authorization: ` Bearer ${tokens.access_token}`,


### PR DESCRIPTION
When `jwtClient.authorize` fails, the outer promise is correctly rejected. *But then* the callback continues with the normal code, causing a `Cannot read property 'access_token' of undefined` exception in line 336 – which is never handled.