### PR TITLE
Fix conv.data not set when init.data has changed issue

### DIFF
--- a/src/service/actionssdk/_test/conv.test.ts
+++ b/src/service/actionssdk/_test/conv.test.ts
@@ -323,6 +323,65 @@ test('conv generates different conv.data correctly', t => {
   })
 })
 
+test('conv generates different conv.data correctly when only with init data', t => {
+  const response = `What's up?`
+  const data = {
+    a: '1',
+    b: '2',
+    c: {
+      d: '3',
+      e: '4',
+    },
+  }
+  const a = '7'
+  const conv = new ActionsSdkConversation<typeof data>({
+    body: {
+      conversation: {
+        conversationToken: JSON.stringify({ data }),
+      },
+    } as Api.GoogleActionsV2AppRequest,
+    init: {
+      data,
+    },
+  })
+  t.deepEqual(conv.data, data)
+  conv.ask(response)
+  conv.data.a = a
+  t.deepEqual(clone(conv.serialize()), {
+    expectUserResponse: true,
+    expectedInputs: [
+      {
+        inputPrompt: {
+          richInitialPrompt: {
+            items: [
+              {
+                simpleResponse: {
+                  textToSpeech: response,
+                },
+              },
+            ],
+          },
+        },
+        possibleIntents: [
+          {
+            intent: 'actions.intent.TEXT',
+          },
+        ],
+      },
+    ],
+    conversationToken: JSON.stringify({
+      data: {
+        a,
+        b: '2',
+        c: {
+          d: '3',
+          e: '4',
+        },
+      },
+    }),
+  })
+})
+
 test('conv generates same conv.data persisted', t => {
   const response = `What's up?`
   const data = {

--- a/src/service/actionssdk/conv.ts
+++ b/src/service/actionssdk/conv.ts
@@ -35,7 +35,7 @@ const deserializeData = <TConvData>(
   const { conversation = {} } = body
   const { conversationToken } = conversation
   const data: TConvData = conversationToken ?
-    JSON.parse(conversationToken).data : (defaultData || {})
+    JSON.parse(conversationToken).data : Object.assign({}, defaultData)
   return data
 }
 

--- a/src/service/dialogflow/_test/conv.test.ts
+++ b/src/service/dialogflow/_test/conv.test.ts
@@ -789,6 +789,63 @@ test('conv generates different conv.data correctly', t => {
   })
 })
 
+test('conv generates different conv.data correctly when only with init data', t => {
+  const session = 'sessionId123'
+  const response = `What's up?`
+  const data = {
+    a: '1',
+    b: '2',
+    c: {
+      d: '3',
+      e: '4',
+    },
+  }
+  const a = '7'
+  const conv = new DialogflowConversation<typeof data>({
+    body: {
+      session,
+    } as Api.GoogleCloudDialogflowV2WebhookRequest,
+    init: {
+      data,
+    },
+  })
+  t.deepEqual(conv.data, data)
+  conv.ask(response)
+  conv.data.a = a
+  t.deepEqual(clone(conv.serialize()), {
+    payload: {
+      google: {
+        expectUserResponse: true,
+        richResponse: {
+          items: [
+            {
+              simpleResponse: {
+                textToSpeech: response,
+              },
+            },
+          ],
+        },
+      },
+    },
+    outputContexts: [
+      {
+        name: `${session}/contexts/_actions_on_google`,
+        lifespanCount: 99,
+        parameters: {
+          data: JSON.stringify({
+            a,
+            b: '2',
+            c: {
+              d: '3',
+              e: '4',
+            },
+          }),
+        },
+      },
+    ],
+  })
+})
+
 test('conv generates same conv.data as no output contexts', t => {
   const session = 'sessionId123'
   const response = `What's up?`

--- a/src/service/dialogflow/conv.ts
+++ b/src/service/dialogflow/conv.ts
@@ -102,7 +102,7 @@ const deserializeData = <TContexts extends Contexts, TConvData>(
     }
   }
 
-  return defaultData || {} as TConvData
+  return Object.assign({}, defaultData) as TConvData
 }
 
 /** @public */


### PR DESCRIPTION
When `conv.data` comes from `this._init.data` and has been mutated somewhere, currently `CONV_DATA_CONTEXT` will not be present in `outputContext`, which means Assistant will not know the change to `conv.data`.

The reason is that, when comparing `convDataOut` with `convDataIn`,  these two variables actually pointed to the same object (i.e., `defaultData` in `deserializeData`). 

To fix this, I propose that `defaultData` should always be copied when used in `deserializeData`.


Related issue: #241 