### PR TITLE
Set own custom logger module to apply a log output solution for each platform

### DIFF
--- a/src/_test/assistant.test.ts
+++ b/src/_test/assistant.test.ts
@@ -17,7 +17,7 @@
 import ava, { TestInterface } from 'ava'
 import * as sinon from 'sinon'
 
-import * as common from '../common'
+import { logger } from '../logging'
 import { JsonObject } from '../common'
 
 import { attach, AppHandler } from '../assistant'
@@ -42,7 +42,7 @@ test('app.frameworks is an object', t => {
 })
 
 test('app.handler throws error by default', async t => {
-  const stub = sinon.stub(common, 'error')
+  const stub = sinon.stub(logger, 'error')
   await t.throwsAsync(t.context.app.handler({}, {}))
   t.true(stub.called)
   stub.restore()
@@ -175,7 +175,7 @@ test('app is callable as a StandardHandler when debug is true', async t => {
     debug: true,
   })
   t.is(typeof app, 'function')
-  const stub = sinon.stub(common, 'info')
+  const stub = sinon.stub(logger, 'info')
   const res = await app(body, headers)
   t.true(stub.called)
   stub.restore()

--- a/src/_test/logging.test.ts
+++ b/src/_test/logging.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/_test/logging.test.ts
+++ b/src/_test/logging.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'ava'
+import * as sinon from 'sinon'
+import { Logger, logger } from '../logging'
+
+test.serial('the custom logger is used when calling each log method', t => {
+  const customLogger = {
+    // tslint:disable-next-line:no-any automatically detect any inputs
+    info(message?: any, ...optionalParams: any[]): void {},
+  } as Logger
+  const stub = sinon.stub(customLogger, 'info')
+  logger.customLogger = customLogger
+  logger.info('message1')
+  t.true(stub.called)
+  stub.restore()
+})

--- a/src/_test/logging.test.ts
+++ b/src/_test/logging.test.ts
@@ -18,6 +18,13 @@ import test from 'ava'
 import * as sinon from 'sinon'
 import { Logger, logger } from '../logging'
 
+test.serial('the default logger is used when calling each log method', t => {
+  const stub = sinon.stub(logger.customLogger, 'error')
+  logger.error('message1')
+  t.true(stub.called)
+  stub.restore()
+})
+
 test.serial('the custom logger is used when calling each log method', t => {
   const customLogger = {
     // tslint:disable-next-line:no-any automatically detect any inputs

--- a/src/assistant.ts
+++ b/src/assistant.ts
@@ -16,7 +16,7 @@
 
 import { OmniHandler, StandardHandler, BuiltinFrameworks, builtin } from './framework'
 import * as common from './common'
-import { logger } from './logging'
+import { logger, Logger } from './logging'
 
 /** @public */
 export type AppHandler = OmniHandler & BaseApp
@@ -25,6 +25,8 @@ export type AppHandler = OmniHandler & BaseApp
 export interface AppOptions {
   /** @public */
   debug?: boolean
+  /** @public */
+  logger?: Logger
 }
 
 /** @hidden */
@@ -68,6 +70,9 @@ export const attach = <TService>(
   service: TService,
   options?: AppOptions,
 ): AppHandler & TService => {
+  if (options && options.logger) {
+    logger.customLogger = options.logger
+  }
   let app: (BaseApp & TService) | (AppHandler & TService) = Object.assign(create(options), service)
   // tslint:disable-next-line:no-any automatically detect any inputs
   const omni: OmniHandler = (...args: any[]) => {

--- a/src/assistant.ts
+++ b/src/assistant.ts
@@ -16,6 +16,7 @@
 
 import { OmniHandler, StandardHandler, BuiltinFrameworks, builtin } from './framework'
 import * as common from './common'
+import { logger } from './logging'
 
 /** @public */
 export type AppHandler = OmniHandler & BaseApp
@@ -80,7 +81,7 @@ export const attach = <TService>(
   app = Object.assign(omni, app)
   const handler: typeof app.handler = app.handler.bind(app)
   const standard: StandardHandler = async (body, headers, metadata) => {
-    const log = app.debug ? common.info : common.debug
+    const log = app.debug ? logger.info.bind(logger) : logger.debug.bind(logger)
     log('Request', common.stringify(body))
     log('Headers', common.stringify(headers))
     const response = await handler(body, headers, metadata)

--- a/src/common.ts
+++ b/src/common.ts
@@ -14,31 +14,7 @@
  * limitations under the License.
  */
 
-import * as Debug from 'debug'
 import * as https from 'https'
-
-const name = 'actions-on-google'
-
-/** @hidden */
-export const debug = Debug(`${name}:debug`)
-
-/** @hidden */
-export const warn = Debug(`${name}:warn`)
-
-/** @hidden */
-// tslint:disable-next-line:no-console Allow console binding
-export const error = console.error.bind(console) as typeof console.error
-
-/** @hidden */
-// tslint:disable-next-line:no-console Allow console binding
-export const info = console.log.bind(console) as typeof console.log
-
-warn.log = error
-debug.log = info
-
-/** @hidden */
-export const deprecate = (feature: string, alternative: string) =>
-  info(`${feature} is *DEPRECATED*: ${alternative}`)
 
 /** @public */
 export interface JsonObject {

--- a/src/framework/_test/express.test.ts
+++ b/src/framework/_test/express.test.ts
@@ -17,8 +17,8 @@
 import ava, { TestInterface } from 'ava'
 import * as sinon from 'sinon'
 
-import * as common from '../../common'
 import { JsonObject } from '../../common'
+import { logger } from '../../logging'
 
 import { Express } from '../express'
 import { StandardResponse, Headers } from '../framework'
@@ -112,7 +112,7 @@ test.serial('handles error', async t => {
   let receivedStatus = -1
   let receivedBody: JsonObject | null = null
   let promise: Promise<StandardResponse> | null = null
-  const stub = sinon.stub(common, 'error')
+  const stub = sinon.stub(logger, 'error')
   t.context.express.handle((body, headers) => {
     t.is(body, sentBody)
     t.is(headers, sentHeaders)
@@ -157,7 +157,7 @@ test.serial('handles string error', async t => {
   let receivedStatus = -1
   let receivedBody: JsonObject | null = null
   let promise: Promise<StandardResponse> | null = null
-  const stub = sinon.stub(common, 'error')
+  const stub = sinon.stub(logger, 'error')
   t.context.express.handle((body, headers) => {
     t.is(body, sentBody)
     t.is(headers, sentHeaders)

--- a/src/framework/_test/lambda.test.ts
+++ b/src/framework/_test/lambda.test.ts
@@ -17,8 +17,8 @@
 import ava, { TestInterface } from 'ava'
 import * as sinon from 'sinon'
 
-import * as common from '../../common'
 import { JsonObject } from '../../common'
+import { logger } from '../../logging'
 
 import { Lambda } from '../lambda'
 import { StandardResponse } from '../framework'
@@ -140,7 +140,7 @@ test.serial('handles error', async t => {
   }
   let receivedError: Error | null = null
   let promise: Promise<StandardResponse> | null = null
-  const stub = sinon.stub(common, 'error')
+  const stub = sinon.stub(logger, 'error')
   t.context.lambda.handle((body, headers) => {
     t.deepEqual(body, sentBody)
     t.deepEqual(headers, sentHeaders)
@@ -173,7 +173,7 @@ test.serial('handles string error', async t => {
   }
   let receivedError: string | null = null
   let promise: Promise<StandardResponse> | null = null
-  const stub = sinon.stub(common, 'error')
+  const stub = sinon.stub(logger, 'error')
   t.context.lambda.handle((body, headers) => {
     t.deepEqual(body, sentBody)
     t.deepEqual(headers, sentHeaders)

--- a/src/framework/express.ts
+++ b/src/framework/express.ts
@@ -20,7 +20,7 @@
 
 import { Framework, StandardHandler } from './framework'
 import { Request, Response } from 'express'
-import * as common from '../common'
+import { logger } from '../logging'
 
 export interface ExpressHandler {
   /** @public */
@@ -53,7 +53,7 @@ export class Express implements Framework<ExpressHandler> {
         response.status(status).send(body)
       })
       .catch((e: Error) => {
-        common.error(e.stack || e)
+        logger.error(e.stack || e)
         response.status(500).send({ error: e.message || e })
       })
     }

--- a/src/framework/lambda.ts
+++ b/src/framework/lambda.ts
@@ -20,7 +20,7 @@
 
 import { Framework, StandardHandler, Headers } from './framework'
 import { JsonObject } from '../common'
-import * as common from '../common'
+import { logger } from '../logging'
 import { Context, Callback } from 'aws-lambda'
 
 export interface LambdaHandler {
@@ -55,7 +55,7 @@ export class Lambda implements Framework<LambdaHandler> {
         (typeof event.body === 'string' ? JSON.parse(event.body) : event.body)
       const result = await standard(body, headers, { lambda: metadata })
       .catch((e: Error) => {
-        common.error(e.stack || e)
+        logger.error(e.stack || e)
         callback(e)
       })
       if (!result) {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Debug from 'debug'
+
+ /** @public */
+export interface Logger {
+  // tslint:disable-next-line:no-any automatically detect any inputs
+  debug(message?: any, ...optionalParams: any[]): void
+  // tslint:disable-next-line:no-any automatically detect any inputs
+  warn(message?: any, ...optionalParams: any[]): void
+  // tslint:disable-next-line:no-any automatically detect any inputs
+  info(message?: any, ...optionalParams: any[]): void
+  // tslint:disable-next-line:no-any automatically detect any inputs
+  error(message?: any, ...optionalParams: any[]): void
+  deprecate(feature: string, alternative: string): void
+}
+
+/** @hidden */
+class DefaultLogger implements Logger {
+  private logName = 'actions-on-google'
+  private debug_ = Debug(`${this.logName}:debug`)
+  private warn_ = Debug(`${this.logName}:warn`)
+  // tslint:disable-next-line:no-console Allow console binding
+  private error_ = console.error.bind(console) as typeof console.error
+  // tslint:disable-next-line:no-console Allow console binding
+  private info_ = console.log.bind(console) as typeof console.log
+
+  constructor() {
+    this.warn_.log = this.error_
+    this.debug_.log = this.info_
+  }
+
+  // tslint:disable-next-line:no-any automatically detect any inputs
+  debug(message?: any, ...optionalParams: any[]): void {
+    this.debug_(message, ...(optionalParams.map(p => JSON.stringify(p, null, 2))))
+  }
+
+  // tslint:disable-next-line:no-any automatically detect any inputs
+  warn(message?: any, ...optionalParams: any[]): void {
+    this.warn_(message, ...optionalParams)
+  }
+
+  // tslint:disable-next-line:no-any automatically detect any inputs
+  info(message?: any, ...optionalParams: any[]): void {
+    this.info_(message, ...(optionalParams.map(p => JSON.stringify(p, null, 2))))
+  }
+
+  // tslint:disable-next-line:no-any automatically detect any inputs
+  error(message?: any, ...optionalParams: any[]): void {
+    this.error_(message, ...optionalParams)
+  }
+
+  deprecate(feature: string, alternative: string): void {
+    this.info_(`${feature} is *DEPRECATED*: ${alternative}`)
+  }
+}
+
+// class LoggingProxy {
+//   private logger: Logger
+
+//   constructor() {
+//     this.logger = new DefaultLogger()
+//   }
+
+//   setCustomLogger(customLogger: Logger): void {
+//     this.logger = customLogger
+//   }
+
+//   // tslint:disable-next-line:no-any automatically detect any inputs
+//   debug(message?: any, ...optionalParams: any[]): void {
+//     this.logger.debug(message, ...optionalParams)
+//   }
+
+//   // tslint:disable-next-line:no-any automatically detect any inputs
+//   warn(message?: any, ...optionalParams: any[]): void {
+//     this.logger.warn(message, ...optionalParams)
+//   }
+
+//   // tslint:disable-next-line:no-any automatically detect any inputs
+//   info(message?: any, ...optionalParams: any[]): void {
+//     console.log('LoggingProxy.info')
+//     this.logger.info(message, ...optionalParams)
+//   }
+
+//   // tslint:disable-next-line:no-any automatically detect any inputs
+//   error(message?: any, ...optionalParams: any[]): void {
+//     this.logger.error(message, ...optionalParams)
+//   }
+
+//   deprecate(feature: string, alternative: string): void {
+//     this.logger.deprecate(feature, alternative)
+//   }
+// }
+
+export const logger = new DefaultLogger()

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -69,41 +69,40 @@ class DefaultLogger implements Logger {
   }
 }
 
-// class LoggingProxy {
-//   private logger: Logger
+class LoggingProxy {
+  private logger: Logger
 
-//   constructor() {
-//     this.logger = new DefaultLogger()
-//   }
+  constructor() {
+    this.logger = new DefaultLogger()
+  }
 
-//   setCustomLogger(customLogger: Logger): void {
-//     this.logger = customLogger
-//   }
+  set customLogger(customLogger: Logger) {
+    this.logger = customLogger
+  }
 
-//   // tslint:disable-next-line:no-any automatically detect any inputs
-//   debug(message?: any, ...optionalParams: any[]): void {
-//     this.logger.debug(message, ...optionalParams)
-//   }
+  // tslint:disable-next-line:no-any automatically detect any inputs
+  debug(message?: any, ...optionalParams: any[]): void {
+    this.logger.debug(message, ...optionalParams)
+  }
 
-//   // tslint:disable-next-line:no-any automatically detect any inputs
-//   warn(message?: any, ...optionalParams: any[]): void {
-//     this.logger.warn(message, ...optionalParams)
-//   }
+  // tslint:disable-next-line:no-any automatically detect any inputs
+  warn(message?: any, ...optionalParams: any[]): void {
+    this.logger.warn(message, ...optionalParams)
+  }
 
-//   // tslint:disable-next-line:no-any automatically detect any inputs
-//   info(message?: any, ...optionalParams: any[]): void {
-//     console.log('LoggingProxy.info')
-//     this.logger.info(message, ...optionalParams)
-//   }
+  // tslint:disable-next-line:no-any automatically detect any inputs
+  info(message?: any, ...optionalParams: any[]): void {
+    this.logger.info(message, ...optionalParams)
+  }
 
-//   // tslint:disable-next-line:no-any automatically detect any inputs
-//   error(message?: any, ...optionalParams: any[]): void {
-//     this.logger.error(message, ...optionalParams)
-//   }
+  // tslint:disable-next-line:no-any automatically detect any inputs
+  error(message?: any, ...optionalParams: any[]): void {
+    this.logger.error(message, ...optionalParams)
+  }
 
-//   deprecate(feature: string, alternative: string): void {
-//     this.logger.deprecate(feature, alternative)
-//   }
-// }
+  deprecate(feature: string, alternative: string): void {
+    this.logger.deprecate(feature, alternative)
+  }
+}
 
-export const logger = new DefaultLogger()
+export const logger = new LoggingProxy()

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -70,38 +70,42 @@ class DefaultLogger implements Logger {
 }
 
 class LoggingProxy {
-  private logger: Logger
+  private logger_: Logger
 
   constructor() {
-    this.logger = new DefaultLogger()
+    this.logger_ = new DefaultLogger()
   }
 
   set customLogger(customLogger: Logger) {
-    this.logger = customLogger
+    this.logger_ = customLogger
+  }
+
+  get customLogger(): Logger {
+    return this.logger_
   }
 
   // tslint:disable-next-line:no-any automatically detect any inputs
   debug(message?: any, ...optionalParams: any[]): void {
-    this.logger.debug(message, ...optionalParams)
+    this.logger_.debug(message, ...optionalParams)
   }
 
   // tslint:disable-next-line:no-any automatically detect any inputs
   warn(message?: any, ...optionalParams: any[]): void {
-    this.logger.warn(message, ...optionalParams)
+    this.logger_.warn(message, ...optionalParams)
   }
 
   // tslint:disable-next-line:no-any automatically detect any inputs
   info(message?: any, ...optionalParams: any[]): void {
-    this.logger.info(message, ...optionalParams)
+    this.logger_.info(message, ...optionalParams)
   }
 
   // tslint:disable-next-line:no-any automatically detect any inputs
   error(message?: any, ...optionalParams: any[]): void {
-    this.logger.error(message, ...optionalParams)
+    this.logger_.error(message, ...optionalParams)
   }
 
   deprecate(feature: string, alternative: string): void {
-    this.logger.deprecate(feature, alternative)
+    this.logger_.deprecate(feature, alternative)
   }
 }
 

--- a/src/service/actionssdk/_test/conv.test.ts
+++ b/src/service/actionssdk/_test/conv.test.ts
@@ -17,8 +17,8 @@
 import test from 'ava'
 import * as sinon from 'sinon'
 
-import * as common from '../../../common'
 import { clone } from '../../../common'
+import { logger } from '../../../logging'
 
 import * as Api from '../api/v2'
 
@@ -98,7 +98,7 @@ test('new conversation', t => {
   t.is(conv.body, appRequest)
   t.is(conv.intent, intent)
   t.is(conv.id, CONVERSATION_ID)
-  const stub = sinon.stub(common, 'deprecate')
+  const stub = sinon.stub(logger, 'deprecate')
   t.is(conv.user.id, USER_ID)
   t.true(stub.called)
   stub.restore()

--- a/src/service/actionssdk/actionssdk.ts
+++ b/src/service/actionssdk/actionssdk.ts
@@ -28,6 +28,7 @@ import {
 import { ActionsSdkConversation } from './conv'
 import { OAuth2Client } from 'google-auth-library'
 import * as common from '../../common'
+import { logger } from '../../logging'
 import { BuiltinFrameworkMetadata } from '../../framework'
 
 /** @public */
@@ -346,7 +347,7 @@ export const actionssdk: ActionsSdk = <
         ActionsSdkConversation<TConvData, TUserStorage>
       )
     }
-    const log = debug ? common.info : common.debug
+    const log = debug ? logger.info.bind(logger) : logger.debug.bind(logger)
     log('Conversation', common.stringify(conv, 'request', 'headers', 'body'))
     const { intent } = conv
     const traversed: Traversed = {}

--- a/src/service/actionssdk/conversation/_test/user.test.ts
+++ b/src/service/actionssdk/conversation/_test/user.test.ts
@@ -17,7 +17,7 @@
 import test from 'ava'
 import * as sinon from 'sinon'
 
-import * as common from '../../../../common'
+import { logger } from '../../../../logging'
 
 import { User, Profile } from '../user'
 
@@ -47,7 +47,7 @@ test('user reads userId', t => {
   const user = new User({
     userId: id,
   })
-  const stub = sinon.stub(common, 'deprecate')
+  const stub = sinon.stub(logger, 'deprecate')
   t.is(user.id, id)
   t.true(stub.called)
   stub.restore()

--- a/src/service/actionssdk/conversation/helper/deeplink.ts
+++ b/src/service/actionssdk/conversation/helper/deeplink.ts
@@ -16,7 +16,8 @@
 
 import * as Api from '../../api/v2'
 import { Helper } from './helper'
-import { ProtoAny, deprecate } from '../../../../common'
+import { ProtoAny } from '../../../../common'
+import { logger } from '../../../../logging'
 import { DialogSpec } from '../conversation'
 
 /**
@@ -114,7 +115,7 @@ export class DeepLink extends Helper<
    * @public
    */
   constructor(options: DeepLinkOptions) {
-    deprecate('DeepLink', 'Access will be by request only')
+    logger.deprecate('DeepLink', 'Access will be by request only')
 
     const extension: ProtoAny<DialogSpec, Api.GoogleActionsV2LinkValueSpecLinkDialogSpec> = {
       '@type': 'type.googleapis.com/google.actions.v2.LinkValueSpec.LinkDialogSpec',

--- a/src/service/actionssdk/conversation/user.ts
+++ b/src/service/actionssdk/conversation/user.ts
@@ -17,7 +17,7 @@
 import * as Api from '../api/v2'
 import { OAuth2Client } from 'google-auth-library'
 import { LoginTicket, TokenPayload } from 'google-auth-library/build/src/auth/loginticket'
-import * as common from '../../../common'
+import { logger } from '../../../logging'
 
 export class Last {
   /**
@@ -310,7 +310,7 @@ export class User<TUserStorage> {
    * @public
    */
   get id() {
-    common.deprecate('conv.user.id', 'Use conv.user.storage to store data instead')
+    logger.deprecate('conv.user.id', 'Use conv.user.storage to store data instead')
     return this._id
   }
 

--- a/src/service/dialogflow/dialogflow.ts
+++ b/src/service/dialogflow/dialogflow.ts
@@ -26,6 +26,7 @@ import {
   UnauthorizedError,
 } from '../actionssdk'
 import * as common from '../../common'
+import { logger } from '../../logging'
 import { Contexts, Parameters } from './context'
 import { DialogflowConversation } from './conv'
 import { OAuth2Client } from 'google-auth-library'
@@ -491,7 +492,7 @@ export const dialogflow: Dialogflow = <
         DialogflowConversation<TConvData, TUserStorage, TContexts>
       )
     }
-    const log = debug ? common.info : common.debug
+    const log = debug ? logger.info.bind(logger) : logger.debug.bind(logger)
     log('Conversation', common.stringify(conv, 'request', 'headers', 'body'))
     const { intent } = conv
     const traversed: Traversed = {}


### PR DESCRIPTION
Fixes #337 

## Abstract

This pull request provides a new feature to set own custom logger module.

## Detail

This pull request has some modifications like the following:

* Currently, each log function are defined on the `common` module. This pull request removes them from the `common` module. Instead, this pull request introduces a new module named 'logging'.
* The `logging` module defines three elements: `Logger` interface, `DefaultLogger` class and `LoggerProxy` class.
* The `Logger` interface defines each log function signature including `debug`, `error`, `info`, `warn` and `deprecate`.
* The `DefaultLogger` class has same features which the current `common` module is providing.
* The `LoggerProxy` class is a proxy class. Actually, the `logging` module exports this instance named `logger`. The `LoggerProxy` class delegates each function call to the implementation instance. The `DefaultLogger` class is one of the implementation, and the initial `LoggerProxy` instance has the `DefaultLogger` instance so that this client library can provide same behaviors of the latest version.
* All codes which calls `common.<debug, error, warn, info>()` are replaced with `logging.<debug, error, warn, info>()`.

Developers can define own custom logger with the `Logger` interface like the following:

```js
const customLogger = {
  debug(message?: any, ...optionParams?: any[]) {
    // Write a log with arguments by own method/format...
  },
  ...
} as Logger;
```

And, the developers can specify the own logger above with like the following:

```js
import { dialogflow } from `actions-on-google`;

const app = dialogflow({
  logger: customLogger
});
```
