### PR TITLE
Make execution params field optional

### DIFF
--- a/src/service/smarthome/api/v1.ts
+++ b/src/service/smarthome/api/v1.ts
@@ -59,7 +59,7 @@ export interface SmartHomeV1QueryRequest {
 
 export interface SmartHomeV1ExecuteRequestExecution {
   command: string,
-  params: ApiClientObjectMap<any>,
+  params?: ApiClientObjectMap<any>,
   challenge?: {
     pin?: string,
     ack?: boolean,


### PR DESCRIPTION
Hi,
according to the docs, the `params` field of `SmartHomeV1ExecuteRequestExecution` isn't mandatory.
See: https://developers.google.com/actions/smarthome/traits/dock#device-commands

Cheers