### PR TITLE
Support configuring loggers as described in issue #413

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -16,22 +16,27 @@
 
 import * as Debug from 'debug'
 import * as https from 'https'
+import { AppLogs } from './assistant'
 
 const name = 'actions-on-google'
 
 /** @hidden */
-export const debug = Debug(`${name}:debug`)
+let debug = Debug(`${name}:debug`)
+export { debug }
 
 /** @hidden */
-export const warn = Debug(`${name}:warn`)
+let warn = Debug(`${name}:warn`)
+export { warn }
 
 /** @hidden */
 // tslint:disable-next-line:no-console Allow console binding
-export const error = console.error.bind(console) as typeof console.error
+let error = console.error.bind(console) as typeof console.error
+export { error }
 
 /** @hidden */
 // tslint:disable-next-line:no-console Allow console binding
-export const info = console.log.bind(console) as typeof console.log
+let info = console.log.bind(console) as typeof console.log
+export { info }
 
 warn.log = error
 debug.log = info
@@ -51,6 +56,13 @@ export const values = <T>(o: { [key: string]: T }) => Object.keys(o).map(k => o[
 
 /** @hidden */
 export const clone = <T>(o: T): T => JSON.parse(JSON.stringify(o))
+
+export const setLogs = (logs: AppLogs) => {
+  debug.log = logs.debug
+  info = logs.info
+  warn.log = logs.warn
+  error = logs.error
+}
 
 /** @hidden */
 // tslint:disable-next-line:no-any root can be anything


### PR DESCRIPTION
(https://github.com/actions-on-google/actions-on-google-nodejs/issues/413).

With that change, a client application that uses Firebase cloud functions would simply need to do the following to improve substantially the readability of log entries in the cloud functions logs console:

const app = smarthome({
  debug: true,
  logs: {
    debug: functions.logger.debug,
    info: functions.logger.info,
    // 'warn' maps to 'error' in firebase logs.
    // If set to functions.logger.warn, there is no level associated with the log entry.
    warn: functions.logger.error,
    error: functions.logger.error
  }
});