### PR TITLE
Update conversation.ts

### DIFF
--- a/src/service/actionssdk/conversation/conversation.ts
+++ b/src/service/actionssdk/conversation/conversation.ts
@@ -307,7 +307,7 @@ export class Conversation<TUserStorage> {
   _responded = false;
 
   /** @hidden */
-  _init: ConversationOptionsInit<{}, TUserStorage>;
+  _init: ConversationOptionsInit<any, TUserStorage>;
 
   /** @hidden */
   _ordersv3 = false;


### PR DESCRIPTION
Due to newer versions of TypeScript there is a type cast exception for extended classes ActionsSdkConversation and DialogflowConversation. Their generic types TConvData = JsonObject signature and JsonObject cannot be cast to {} ConversationOptionsInit<{}, TUserStorage>.